### PR TITLE
Use io.CopyBuffer for Transfer and add graceful shutdown deadline unblocking

### DIFF
--- a/pkg/transfer.go
+++ b/pkg/transfer.go
@@ -2,47 +2,15 @@ package pkg
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log"
 	"net"
+	"os"
 	"strings"
 	"sync/atomic"
+	"time"
 )
-
-type TransferResult struct {
-	N   int
-	Err error
-}
-
-func read(ctx context.Context, conn net.Conn, buf []byte) TransferResult {
-	ch := make(chan TransferResult)
-	go func() {
-		// ignore if context is done
-		n, err := conn.Read(buf)
-		ch <- TransferResult{n, err}
-	}()
-	select {
-	case <-ctx.Done():
-		return TransferResult{0, ctx.Err()}
-	case res := <-ch:
-		return res
-	}
-}
-
-func write(ctx context.Context, conn net.Conn, buf []byte) TransferResult {
-	ch := make(chan TransferResult)
-	go func() {
-		// ignore if context is done
-		n, err := conn.Write(buf)
-		ch <- TransferResult{n, err}
-	}()
-	select {
-	case <-ctx.Done():
-		return TransferResult{0, ctx.Err()}
-	case res := <-ch:
-		return res
-	}
-}
 
 func Transfer(ctx context.Context, destination, source net.Conn) {
 	defer func() {
@@ -51,28 +19,20 @@ func Transfer(ctx context.Context, destination, source net.Conn) {
 		atomic.AddInt64(&ActiveConnections, -1)
 	}()
 
+	stopCancelHook := context.AfterFunc(ctx, func() {
+		// Unblock io.CopyBuffer when graceful shutdown starts.
+		_ = source.SetReadDeadline(time.Now())
+		_ = destination.SetWriteDeadline(time.Now())
+	})
+	defer stopCancelHook()
+
 	buf := make([]byte, 32*1024)
-	for {
-		readRes := read(ctx, source, buf)
-		if readRes.N > 0 {
-			writeRes := write(ctx, destination, buf[0:readRes.N])
-			// TODO: check nw < 0 or nr < nw, record transferred bytes
-			// ignore errors
-			if writeRes.Err != nil {
-				return
-			}
-			if readRes.N != writeRes.N {
-				return
-			}
-		}
-		if readRes.Err != nil {
-			// TODO filter use of closed network connection error and EOF
-			if readRes.Err != io.EOF &&
-				!strings.Contains(readRes.Err.Error(), "use of closed network connection") &&
-				!strings.Contains(readRes.Err.Error(), "context canceled") {
-				log.Printf("Read error: %v", readRes.Err)
-			}
-			return
-		}
+	_, err := io.CopyBuffer(destination, source, buf)
+	if err != nil &&
+		err != io.EOF &&
+		!strings.Contains(err.Error(), "use of closed network connection") &&
+		!strings.Contains(err.Error(), "context canceled") &&
+		!(ctx.Err() != nil && errors.Is(err, os.ErrDeadlineExceeded)) {
+		log.Printf("Transfer error: %v", err)
 	}
 }


### PR DESCRIPTION
### Motivation
- Simplify the custom read/write loop and reduce goroutine/channel overhead by using the standard `io.CopyBuffer` for data transfer.
- Ensure in-flight `io.CopyBuffer` calls are unblocked during graceful shutdown by setting connection deadlines when the context is canceled.
- Improve error handling to avoid noisy logs for expected shutdown-related errors.

### Description
- Removed the custom `read`, `write`, and `TransferResult` machinery and replaced the loop with a single `io.CopyBuffer(destination, source, buf)` call.
- Added a context cancellation hook using `context.AfterFunc` to call `SetReadDeadline` and `SetWriteDeadline` on the sockets to unblock `io.CopyBuffer` during shutdown, and ensured the hook is canceled with `defer`.
- Expanded imports to include `errors`, `os`, and `time`, and refined error filtering to ignore `io.EOF`, "use of closed network connection", "context canceled", and deadline-exceeded errors when the context was canceled.
- Preserved connection closing and active connection accounting via the existing deferred cleanup.

### Testing
- Ran `go test ./...` which completed successfully without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69edf0ea9ef48325a8bf97308a33c963)